### PR TITLE
Issue openam#83 OpenID Connect authentication fails if jwks_uri content contains x5c

### DIFF
--- a/json-web-token/src/main/java/org/forgerock/json/jose/jwk/EcJWK.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/jwk/EcJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jwk;
@@ -30,7 +31,6 @@ import java.util.List;
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.jose.jws.SupportedEllipticCurve;
-import org.forgerock.util.encode.Base64;
 import org.forgerock.util.encode.Base64url;
 
 /**
@@ -68,10 +68,10 @@ public class EcJWK extends JWK {
      * @param curve The known curve to use. For example "NIST P-256".
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public EcJWK(KeyUse use, String alg, String kid, String x, String y, String d, String curve,
-                 String x5u, String x5t, List<Base64> x5c) {
+                 String x5u, String x5t, List<String> x5c) {
         super(KeyType.EC, use, alg, kid, x5u, x5t, x5c);
         if (x == null || x.isEmpty()) {
             throw new JsonException("x is required for an EcJWK");
@@ -101,10 +101,10 @@ public class EcJWK extends JWK {
      * @param curve The known curve to use. For example "NIST P-256".
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public EcJWK(KeyUse use, String alg, String kid, String x, String y, String curve, String x5u, String x5t,
-                 List<Base64> x5c) {
+                 List<String> x5c) {
         this (use, alg, kid, x, y, null, curve, x5u, x5t, x5c);
     }
 
@@ -164,7 +164,7 @@ public class EcJWK extends JWK {
         KeyUse use = null;
         String x = null, y = null, d = null, curve = null, alg = null, kid = null;
         String x5u = null, x5t = null;
-        List<Base64> x5c = null;
+        List<String> x5c = null;
 
         kty = KeyType.getKeyType(json.get(KTY).asString());
 
@@ -183,7 +183,7 @@ public class EcJWK extends JWK {
 
         x5u = json.get(X5U).asString();
         x5t = json.get(X5T).asString();
-        x5c = json.get(X5C).asList(Base64.class);
+        x5c = json.get(X5C).asList(String.class);
 
         return new EcJWK(use, alg, kid, x, y, d, curve, x5u, x5t, x5c);
     }

--- a/json-web-token/src/main/java/org/forgerock/json/jose/jwk/JWK.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/jwk/JWK.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jwk;
@@ -23,7 +24,6 @@ import java.util.Map;
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.jose.jwt.JWObject;
-import org.forgerock.util.encode.Base64;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -85,9 +85,9 @@ public abstract class JWK extends JWObject {
      * @param kid the JWK key id
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
-    protected JWK(KeyType kty, KeyUse use, String alg, String kid, String x5u, String x5t, List<Base64> x5c) {
+    protected JWK(KeyType kty, KeyUse use, String alg, String kid, String x5u, String x5t, List<String> x5c) {
         super();
         if (kty == null) {
             new JsonException("kty is a required field");
@@ -220,10 +220,10 @@ public abstract class JWK extends JWObject {
     }
 
     /**
-     * Gets a List of base64 encoded chain certs.
-     * @return X509 Cert Chain
+     * Gets a List of X509 chain certs.
+     * @return X509 Cert Chain as list of encoded strings or null if none are available.
      */
-    public List<Base64> getX509Chain() {
-        return get(X5C).asList(Base64.class);
+    public List<String> getX509Chain() {
+        return get(X5C).asList(String.class);
     }
 }

--- a/json-web-token/src/main/java/org/forgerock/json/jose/jwk/OctJWK.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/jwk/OctJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jwk;
@@ -20,7 +21,6 @@ import java.util.List;
 
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
-import org.forgerock.util.encode.Base64;
 
 /**
  * Creates an Octet JWK.
@@ -39,9 +39,9 @@ public class OctJWK extends JWK {
      * @param key the symmetric key
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
-    public OctJWK(KeyUse use, String alg, String kid, String key, String x5u, String x5t, List<Base64> x5c) {
+    public OctJWK(KeyUse use, String alg, String kid, String key, String x5u, String x5t, List<String> x5c) {
         super(KeyType.OCT, use, alg, kid, x5u, x5t, x5c);
         if (key == null || key.isEmpty()) {
             throw new JsonException("key is a required field for an OctJWK");
@@ -82,7 +82,7 @@ public class OctJWK extends JWK {
 
         String k = null, alg = null, kid = null;
         String x5u = null, x5t = null;
-        List<Base64> x5c = null;
+        List<String> x5c = null;
 
         k = json.get(K).asString();
 
@@ -97,7 +97,7 @@ public class OctJWK extends JWK {
 
         x5u = json.get(X5U).asString();
         x5t = json.get(X5T).asString();
-        x5c = json.get(X5C).asList(Base64.class);
+        x5c = json.get(X5C).asList(String.class);
 
         return new OctJWK(use, alg, kid, k, x5u, x5t, x5c);
     }

--- a/json-web-token/src/main/java/org/forgerock/json/jose/jwk/RsaJWK.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/jwk/RsaJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jwk;
@@ -34,7 +35,6 @@ import java.util.List;
 
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
-import org.forgerock.util.encode.Base64;
 import org.forgerock.util.encode.Base64url;
 
 /**
@@ -166,9 +166,9 @@ public class RsaJWK extends JWK {
      * @param e the public exponent JWK
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
-    public RsaJWK(KeyUse use, String alg, String kid, String n, String e, String x5u, String x5t, List<Base64> x5c) {
+    public RsaJWK(KeyUse use, String alg, String kid, String n, String e, String x5u, String x5t, List<String> x5c) {
         this (use, alg, kid, n, e, null, null, null, null, null, null, null, x5u, x5t, x5c);
     }
 
@@ -182,10 +182,10 @@ public class RsaJWK extends JWK {
      * @param d the private exponent JWK
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public RsaJWK(KeyUse use, String alg, String kid, String n, String e, String d, String x5u, String x5t,
-                  List<Base64> x5c) {
+                  List<String> x5c) {
         this (use, alg, kid, n, e, d, null, null, null, null, null, null, x5u, x5t, x5c);
     }
 
@@ -203,10 +203,10 @@ public class RsaJWK extends JWK {
      * @param qi the first CRT Coefficient of the JWK
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public RsaJWK(KeyUse use, String alg, String kid, String n, String e, String p, String q, String dp,
-                  String dq, String qi, String x5u, String x5t, List<Base64> x5c) {
+                  String dq, String qi, String x5u, String x5t, List<String> x5c) {
         this (use, alg, kid, n, e, null, p, q, dp, dq, qi, null, x5u, x5t, x5c);
     }
 
@@ -226,11 +226,11 @@ public class RsaJWK extends JWK {
      * @param factors the extra factors of the JWK
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public RsaJWK(KeyUse use, String alg, String kid, String n, String e, String d, String p, String q,
                   String dp, String dq, String qi, List<OtherFactors> factors,
-                  String x5u, String x5t, List<Base64> x5c) {
+                  String x5u, String x5t, List<String> x5c) {
         super(KeyType.RSA, use, alg, kid, x5u, x5t, x5c);
         if (n != null && !n.isEmpty()) {
             put(N, n);
@@ -282,9 +282,9 @@ public class RsaJWK extends JWK {
      * @param key the RSAPublicKey to use
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
-    public RsaJWK(RSAPublicKey key, KeyUse use, String alg, String kid, String x5u, String x5t, List<Base64> x5c) {
+    public RsaJWK(RSAPublicKey key, KeyUse use, String alg, String kid, String x5u, String x5t, List<String> x5c) {
         this(use, alg, kid,
                 Base64url.encode(key.getModulus().toByteArray()),
                 Base64url.encode(key.getPublicExponent().toByteArray()),
@@ -299,10 +299,10 @@ public class RsaJWK extends JWK {
      * @param privKey the RSAPrivateKey to use
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public RsaJWK(RSAPublicKey pubKey, RSAPrivateKey privKey, KeyUse use, String alg, String kid,
-                  String x5u, String x5t, List<Base64> x5c) {
+                  String x5u, String x5t, List<String> x5c) {
         this(use, alg, kid,
                 Base64url.encode(pubKey.getModulus().toByteArray()),
                 Base64url.encode(pubKey.getPublicExponent().toByteArray()),
@@ -318,10 +318,10 @@ public class RsaJWK extends JWK {
      * @param privCert the RSAPrivateCrtKey to use
      * @param x5u the x509 url for the key
      * @param x5t the x509 thumbnail for the key
-     * @param x5c the x509 chain
+     * @param x5c the x509 chain as a list of Base64 encoded strings
      */
     public RsaJWK(RSAPublicKey pubKey, RSAPrivateCrtKey privCert, KeyUse use, String alg, String kid,
-                  String x5u, String x5t, List<Base64> x5c) {
+                  String x5u, String x5t, List<String> x5c) {
         this(use, alg, kid,
                 Base64url.encode(pubKey.getModulus().toByteArray()),
                 Base64url.encode(pubKey.getPublicExponent().toByteArray()),
@@ -508,7 +508,7 @@ public class RsaJWK extends JWK {
 
         String n = null, e = null, d = null, p = null, q = null, dq = null, dp = null, qi = null;
         String x5u = null, x5t = null;
-        List<Base64> x5c = null;
+        List<String> x5c = null;
         List<Object> factors = null;
         List<OtherFactors> listOfFactors = null;
 
@@ -536,7 +536,7 @@ public class RsaJWK extends JWK {
         factors = json.get(FACTORS).asList();
         x5u = json.get(X5U).asString();
         x5t = json.get(X5T).asString();
-        x5c = json.get(X5C).asList(Base64.class);
+        x5c = json.get(X5C).asList(String.class);
         if (factors != null && !factors.isEmpty()) {
             listOfFactors = new ArrayList<>(factors.size());
             for (Object factor : factors) {

--- a/json-web-token/src/test/java/org/forgerock/json/jose/jwk/RsaJWKTest.java
+++ b/json-web-token/src/test/java/org/forgerock/json/jose/jwk/RsaJWKTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jwk;
@@ -21,6 +22,7 @@ import org.forgerock.util.encode.Base64url;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -28,9 +30,11 @@ import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.HashMap;
+import java.util.List;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.testng.Assert.*;
 
 public class RsaJWKTest {
 
@@ -90,6 +94,19 @@ public class RsaJWKTest {
     private static final String QI_SP = "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzg"
             + "UIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rx"
             + "yR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU";
+    private static final String X5C = "[\"MIICQDCCAakCBEeNB0swDQYJKoZIhvcNAQEEBQAwZzELMAkGA1UEBhMCVVMxEzAR"
+            + "BgNVBAgTCkNhbGlmb3JuaWExFDASBgNVBAcTC1NhbnRhIENsYXJhMQwwCgYDVQQK"
+            + "EwNTdW4xEDAOBgNVBAsTB09wZW5TU08xDTALBgNVBAMTBHRlc3QwHhcNMDgwMTE1"
+            + "MTkxOTM5WhcNMTgwMTEyMTkxOTM5WjBnMQswCQYDVQQGEwJVUzETMBEGA1UECBMK"
+            + "Q2FsaWZvcm5pYTEUMBIGA1UEBxMLU2FudGEgQ2xhcmExDDAKBgNVBAoTA1N1bjEQ"
+            + "MA4GA1UECxMHT3BlblNTTzENMAsGA1UEAxMEdGVzdDCBnzANBgkqhkiG9w0BAQEF"
+            + "AAOBjQAwgYkCgYEArSQc/U75GB2AtKhbGS5piiLkmJzqEsp64rDxbMJ+xDrye0EN"
+            + "/q1U5Of+RkDsaN/igkAvV1cuXEgTL6RlafFPcUX7QxDhZBhsYF9pbwtMzi4A4su9"
+            + "hnxIhURebGEmxKW9qJNYJs0Vo5+IgjxuEWnjnnVgHTs1+mq5QYTA7E6ZyL8CAwEA"
+            + "ATANBgkqhkiG9w0BAQQFAAOBgQB3Pw/UQzPKTPTYi9upbFXlrAKMwtFf2OW4yvGW"
+            + "WvlcwcNSZJmTJ8ARvVYOMEVNbsT4OFcfu2/PeYoAdiDAcGy/F2Zuj8XJJpuQRSE6"
+            + "PtQqBuDEHjjmOQJ0rV/r8mO1ZCtHRhpZ5zYRjhRC9eCbjx9VrFax0JDC/FfwWigm"
+            + "rW0Y0Q==\"]";
 
     private static final String ALG = "RS256";
     private static final String KID = "2011-04-29";
@@ -97,10 +114,12 @@ public class RsaJWKTest {
 
     //json objects
     private String json = null;
+    private String jsonWithX5C = null;
     private JsonValue jsonValue = null;
+    private JsonValue jsonValueWithX5C = null;
 
     @BeforeClass
-    public void setup() {
+    public void setup() throws IOException {
         /*{
          "kty":"RSA",
           "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4
@@ -132,7 +151,20 @@ public class RsaJWKTest {
      UIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rx
      yR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
           "alg":"RS256",
-          "kid":"2011-04-29"
+          "kid":"2011-04-29",
+          "x5c":"["MIICQDCCAakCBEeNB0swDQYJKoZIhvcNAQEEBQAwZzELMAkGA1UEBhMCVVMxEzAR
+                   BgNVBAgTCkNhbGlmb3JuaWExFDASBgNVBAcTC1NhbnRhIENsYXJhMQwwCgYDVQQK
+                   EwNTdW4xEDAOBgNVBAsTB09wZW5TU08xDTALBgNVBAMTBHRlc3QwHhcNMDgwMTE1
+                   MTkxOTM5WhcNMTgwMTEyMTkxOTM5WjBnMQswCQYDVQQGEwJVUzETMBEGA1UECBMK
+                   Q2FsaWZvcm5pYTEUMBIGA1UEBxMLU2FudGEgQ2xhcmExDDAKBgNVBAoTA1N1bjEQ
+                   MA4GA1UECxMHT3BlblNTTzENMAsGA1UEAxMEdGVzdDCBnzANBgkqhkiG9w0BAQEF
+                   AAOBjQAwgYkCgYEArSQc/U75GB2AtKhbGS5piiLkmJzqEsp64rDxbMJ+xDrye0EN
+                   /q1U5Of+RkDsaN/igkAvV1cuXEgTL6RlafFPcUX7QxDhZBhsYF9pbwtMzi4A4su9
+                   hnxIhURebGEmxKW9qJNYJs0Vo5+IgjxuEWnjnnVgHTs1+mq5QYTA7E6ZyL8CAwEA
+                   ATANBgkqhkiG9w0BAQQFAAOBgQB3Pw/UQzPKTPTYi9upbFXlrAKMwtFf2OW4yvGW
+                   WvlcwcNSZJmTJ8ARvVYOMEVNbsT4OFcfu2/PeYoAdiDAcGy/F2Zuj8XJJpuQRSE6
+                   PtQqBuDEHjjmOQJ0rV/r8mO1ZCtHRhpZ5zYRjhRC9eCbjx9VrFax0JDC/FfwWigm
+                   rW0Y0Q=="]
           }
          */
         //create string rsa JWT
@@ -152,6 +184,24 @@ public class RsaJWKTest {
                 .append("}");
         json = sb.toString();
 
+        //create string rsa JWT with optional X5C value
+        sb = new StringBuilder();
+        sb.append("{")
+          .append("\"kty\"").append(":").append("\"" + KTY + "\"").append(",")
+          .append("\"n\"").append(":").append("\"" + N + "\"").append(",")
+          .append("\"e\"").append(":").append("\"" + E + "\"").append(",")
+          .append("\"d\"").append(":").append("\"" + D + "\"").append(",")
+          .append("\"p\"").append(":").append("\"" + P + "\"").append(",")
+          .append("\"q\"").append(":").append("\"" + Q + "\"").append(",")
+          .append("\"dp\"").append(":").append("\"" + DP + "\"").append(",")
+          .append("\"dq\"").append(":").append("\"" + DQ + "\"").append(",")
+          .append("\"qi\"").append(":").append("\"" + QI + "\"").append(",")
+          .append("\"alg\"").append(":").append("\"" + ALG + "\"").append(",")
+          .append("\"kid\"").append(":").append("\"" + KID + "\"").append(",")
+          .append("\"x5c\"").append(":").append(X5C)
+          .append("}");
+        jsonWithX5C = sb.toString();
+
         //create json value object
         jsonValue = new JsonValue(new HashMap<>());
         jsonValue.put("kty", KTY);
@@ -165,6 +215,21 @@ public class RsaJWKTest {
         jsonValue.put("qi", QI);
         jsonValue.put("alg", ALG);
         jsonValue.put("kid", KID);
+
+        //create json value object with optional X5C value
+        jsonValueWithX5C = new JsonValue(new HashMap<>());
+        jsonValueWithX5C.put("kty", KTY);
+        jsonValueWithX5C.put("n", N);
+        jsonValueWithX5C.put("e", E);
+        jsonValueWithX5C.put("d", D);
+        jsonValueWithX5C.put("p", P);
+        jsonValueWithX5C.put("q", Q);
+        jsonValueWithX5C.put("dp", DP);
+        jsonValueWithX5C.put("dq", DQ);
+        jsonValueWithX5C.put("qi", QI);
+        jsonValueWithX5C.put("alg", ALG);
+        jsonValueWithX5C.put("kid", KID);
+        jsonValueWithX5C.put("x5c", new ObjectMapper().readValue(X5C, List.class));
     }
 
     @Test
@@ -183,6 +248,18 @@ public class RsaJWKTest {
         assertEquals(jwk.getPrimePExponent(), DP);
         assertEquals(jwk.getPrimeQExponent(), DQ);
         assertEquals(jwk.getCRTCoefficient(), QI);
+        assertNull(jwk.getX509Chain());
+    }
+
+    @Test
+    public void testCreateJWKWithX5CFromAString() throws IOException  {
+        //Given
+
+        //When
+        RsaJWK jwk = RsaJWK.parse(jsonWithX5C);
+
+        //Then
+        assertEquals(jwk.getX509Chain(), new ObjectMapper().readValue(X5C, List.class));
     }
 
     @Test
@@ -201,6 +278,18 @@ public class RsaJWKTest {
         assertEquals(jwk.getPrimePExponent(), DP);
         assertEquals(jwk.getPrimeQExponent(), DQ);
         assertEquals(jwk.getCRTCoefficient(), QI);
+        assertNull(jwk.getX509Chain());
+    }
+
+    @Test
+    public void testCreateJWKWithX5CFromAJsonValue() throws IOException {
+        //Given
+
+        //When
+        RsaJWK jwk = RsaJWK.parse(jsonValueWithX5C);
+
+        //Then
+        assertEquals(jwk.getX509Chain(), new ObjectMapper().readValue(X5C, List.class));
     }
 
     @Test


### PR DESCRIPTION
## Analysis

When using Oauth2.0/OpenID Connect authentication module and validation type is jwk_url, this authentication module accesses jwks_url. 
If this module receives json value contains x5c parameter, json parsing fails.
This should be handled with strings instead of base64,Because x5c value is Base64 encoded string value, not Base64 instance.
`asList` method of `org.forgerock.json.JsonValue` checks if it is an instance of the class specified by the argument.
`org.forgerock.util.encode.Base64` is a utility class and has encoding / decoding methods.
We should not treat this class as a data class for Base64 strings.
See.  JSON Web Signature (JWS) RFC7515.

## Solution

This fix is backport of COMMONS-98(80c589a)

## Testing

* Try openam-jp/openam#83 "Steps to reproduce"
* Unit Test (RsaJWKTest) 
  * `mvn -f json-web-token test -Dtest=RsaJWKTest`
