### PR TITLE
Issue openam#82 Support RS384/RS512 signature algorithm for ID token

### DIFF
--- a/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwsAlgorithm.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwsAlgorithm.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.json.jose.jws;
@@ -37,6 +38,10 @@ public enum JwsAlgorithm implements Algorithm {
     HS512("HmacSHA512", "SHA-512", JwsAlgorithmType.HMAC),
     /** RSA using SHA-256 hash algorithm. **/
     RS256("SHA256withRSA", "SHA-256", JwsAlgorithmType.RSA),
+    /** RSA using SHA-384 hash algorithm. **/
+    RS384("SHA384withRSA", "SHA-384", JwsAlgorithmType.RSA),
+    /** RSA using SHA-512 hash algorithm. **/
+    RS512("SHA512withRSA", "SHA-512", JwsAlgorithmType.RSA),
     /** ECDSA using SHA-256 hash algorithm. */
     ES256("SHA256WithECDSA", "SHA-256", JwsAlgorithmType.ECDSA),
     /** ECDSA using SHA-384 hash algorithm. */

--- a/json-web-token/src/test/java/org/forgerock/json/jose/jws/handlers/RSASigningHandlerTest.java
+++ b/json-web-token/src/test/java/org/forgerock/json/jose/jws/handlers/RSASigningHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2019 Open Source Solution Technology Corporation
+ */
+
+package org.forgerock.json.jose.jws.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.forgerock.json.jose.helper.KeysHelper;
+import org.forgerock.json.jose.jws.JwsAlgorithm;
+import org.forgerock.json.jose.jws.SigningManager;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class RSASigningHandlerTest {
+
+    @Test(dataProvider = "supportedAlgorithms")
+    public void shouldEncodeSignatureCorrectly(JwsAlgorithm algorithm) throws Exception {
+        // Given
+        SigningHandler signingHandler = new SigningManager().newRsaSigningHandler(KeysHelper.getRSAPrivateKey());
+        final byte[] data = "Sample Message".getBytes(StandardCharsets.UTF_8);
+        int expectedSize = KeysHelper.getRSAPrivateKey().getModulus().bitLength() / 8;
+
+        // When
+        final byte[] signature = signingHandler.sign(algorithm, data);
+
+        // Then
+        assertThat(signature).hasSize(expectedSize);
+    }
+
+    @Test(dataProvider = "supportedAlgorithms")
+    public void shouldVerifyCorrectly(JwsAlgorithm algorithm) throws Exception {
+        // Given
+        SigningHandler signingHandler = new SigningManager().newRsaSigningHandler(KeysHelper.getRSAPrivateKey());
+        SigningHandler verificationHandler = new SigningManager().newRsaSigningHandler(KeysHelper.getRSAPublicKey());
+        final byte[] data = "Sample Message".getBytes(StandardCharsets.UTF_8);
+        final byte[] signature = signingHandler.sign(algorithm, data);
+
+        // When
+        boolean valid = verificationHandler.verify(algorithm, data, signature);
+
+        // Then
+        assertThat(valid).isTrue();
+    }
+
+    @Test(dataProvider = "supportedAlgorithms")
+    public void shouldDetectTampering(JwsAlgorithm algorithm) throws Exception {
+        // Given
+        SigningHandler signingHandler = new SigningManager().newRsaSigningHandler(KeysHelper.getRSAPrivateKey());
+        SigningHandler verificationHandler = new SigningManager().newRsaSigningHandler(KeysHelper.getRSAPublicKey());
+        final byte[] data = "Sample Message".getBytes(StandardCharsets.UTF_8);
+        final byte[] signature = signingHandler.sign(algorithm, data);
+
+        data[0] = 0; // Make a change to the data
+
+        // When
+        boolean valid = verificationHandler.verify(algorithm, data, signature);
+
+        // Then
+        assertThat(valid).isFalse();
+    }
+
+    @DataProvider
+    public static Object[][] supportedAlgorithms () {
+        return new Object[][] {
+                { JwsAlgorithm.RS256 },
+                { JwsAlgorithm.RS384 },
+                { JwsAlgorithm.RS512 }
+        };
+    }
+}


### PR DESCRIPTION
## Analysis

In order for OpenAM to support RS384/RS512 for ID token, JWT library also needs to support itself.

*Note: 
After this fix, we shuould modify the default settings of OAuth provider  on OpenAM side.*

## Solution

* Add RS384 and RS512 to JwsAlgorithm enum
* Add unit test for RS algorithms

## Testing

```
mvn test -f json-web-token -Dtest=RSASigningHandlerTest
```