### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/audit/forgerock-audit-handler-jdbc/pom.xml
+++ b/audit/forgerock-audit-handler-jdbc/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -28,10 +29,6 @@
     <packaging>bundle</packaging>
     <name>Commons - ForgeRock Audit JDBC Event Handler</name>
     <description>Writes audit event to a configured JDBC database</description>
-
-    <properties>
-        <h2database.version>1.4.188</h2database.version>
-    </properties>
 
     <dependencies>
         <!-- Third party dependencies -->
@@ -92,7 +89,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${h2database.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-handler-jms/pom.xml
+++ b/audit/forgerock-audit-handler-jms/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -33,7 +34,6 @@
         <dependency>
             <groupId>javax.jms</groupId>
             <artifactId>javax.jms-api</artifactId>
-            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,14 +31,6 @@
     <name>Commons - ForgeRock Audit Framework</name>
     <description>Implements the commons audit framework.</description>
 
-    <properties>
-        <jodaTime.version>2.1</jodaTime.version>
-        <supercsv.version>2.4.0</supercsv.version>
-        <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-        <javax.inject.version>1_2</javax.inject.version>
-        <hikaricp.version>2.4.1</hikaricp.version>
-    </properties>
-
     <modules>
         <module>forgerock-audit-core</module>
         <module>forgerock-audit-json</module>
@@ -51,34 +44,12 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- ForgeRock commons dependencies -->
             <dependency>
-                <groupId>org.apache.servicemix.bundles</groupId>
-                <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
-                <version>${javax.inject.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>${hikaricp.version}</version>
-            </dependency>
-
-            <!-- Third party dependencies -->
-            <dependency>
-                <groupId>net.sf.supercsv</groupId>
-                <artifactId>super-csv</artifactId>
-                <version>${supercsv.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${jodaTime.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet-api.version}</version>
-                <scope>provided</scope>
+                <groupId>jp.openam.commons</groupId>
+                <artifactId>forgerock-bom</artifactId>
+                <version>4.1.2-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
@@ -14,6 +14,7 @@
 *
 * Copyright 2013-2014 ForgeRock AS.
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -57,7 +58,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -14,6 +14,7 @@
 *
 * Copyright 2014-2016 ForgeRock AS.
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -183,8 +184,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/auth-filters/pom.xml
+++ b/auth-filters/pom.xml
@@ -14,6 +14,7 @@
   *
   * Copyright 2013-2016 ForgeRock AS.
   * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -103,17 +104,6 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.security.auth.message</artifactId>
-                <version>3.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jayway.restassured</groupId>
-                <artifactId>rest-assured</artifactId>
-                <version>2.3.0</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/http-framework/binding-test-utils/pom.xml
+++ b/http-framework/binding-test-utils/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jp.openam.http</groupId>
@@ -47,10 +48,12 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/http-framework/http-benchmarks/pom.xml
+++ b/http-framework/http-benchmarks/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -31,12 +32,10 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>${jmh.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>${jmh.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -47,7 +46,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jmh.version>1.12</jmh.version>
     <javac.target>1.7</javac.target>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>

--- a/http-framework/http-client-apache-common/pom.xml
+++ b/http-framework/http-client-apache-common/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -40,7 +41,6 @@
       <!-- This dependency is inherited by both the synchronous and asynchronous AHC CHF Drivers.
            The asynchronous driver has a dependency on 'httpasyncclient' (that itself depends on 'httpclient'),
             so make sure that there is no incompatibility before updating theses versions -->
-      <version>4.4.1</version>
     </dependency>
   </dependencies>
 

--- a/http-framework/http-examples/http-servlet-example/pom.xml
+++ b/http-framework/http-examples/http-servlet-example/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -40,7 +41,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/http-framework/http-grizzly/pom.xml
+++ b/http-framework/http-grizzly/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -29,7 +30,6 @@
     <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-server</artifactId>
-      <version>2.3.24</version>
     </dependency>
     <dependency>
       <groupId>jp.openam.http</groupId>

--- a/http-framework/http-servlet/pom.xml
+++ b/http-framework/http-servlet/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2014-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -65,13 +66,11 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.15.v20140411</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.15.v20140411</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/http-framework/pom.xml
+++ b/http-framework/pom.xml
@@ -15,6 +15,7 @@
   Copyright 2010–2011 ApexIdentity Inc.
   Portions Copyright 2011-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -59,12 +60,6 @@
   </build>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.xebialabs.restito</groupId>
-        <artifactId>restito</artifactId>
-        <version>0.5.1</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>jp.openam.http</groupId>
         <artifactId>binding-test-utils</artifactId>

--- a/json-crypto/pom.xml
+++ b/json-crypto/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -47,20 +48,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.5</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-cli</groupId>
-                <artifactId>commons-cli</artifactId>
-                <version>1.2</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <reporting>
         <plugins>
             <plugin>

--- a/json-patch/pom.xml
+++ b/json-patch/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2011-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -44,7 +45,6 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.rhino</artifactId>
-            <version>1.7R4_1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/json-schema/json-schema-cli/pom.xml
+++ b/json-schema/json-schema-cli/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -47,7 +48,6 @@
         <dependency>
             <groupId>args4j</groupId>
             <artifactId>args4j</artifactId>
-            <version>2.0.16</version>
         </dependency>
     </dependencies>
     <build>

--- a/json-schema/json-schema-core/pom.xml
+++ b/json-schema/json-schema-core/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +35,6 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/json-resource-http/pom.xml
+++ b/rest/json-resource-http/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -60,7 +61,6 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
-            <version>2.3.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -58,11 +59,6 @@
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-core</artifactId>
                 <version>${i18nFrameworkVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
-                <version>1.5.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
+++ b/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.core.config;
 
@@ -38,7 +39,7 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
  */
 class ClassNameFallbackPropertyTypeDeserializer extends AsPropertyTypeDeserializer {
     public ClassNameFallbackPropertyTypeDeserializer(JavaType bt, TypeIdResolver idRes, String typePropertyName,
-            boolean typeIdVisible, Class<?> defaultImpl) {
+            boolean typeIdVisible, JavaType defaultImpl) {
         super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl);
     }
 
@@ -77,7 +78,7 @@ class ClassNameFallbackPropertyTypeDeserializer extends AsPropertyTypeDeserializ
                     // ensure the type we found is assignable to the base type requested by deserialization;
                     // typically this is the interface or base class
                     if (_baseType != null && _baseType.getClass() == type.getClass()) {
-                        type = _baseType.narrowBy(type.getRawClass());
+                        type = context.getTypeFactory().constructSpecializedType( _baseType, type.getRawClass());
                     }
                     // find an appropriate deserializer for this type and deserialize
                     JsonDeserializer<Object> deser = context.findContextualValueDeserializer(type, _property);

--- a/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeResolver.java
+++ b/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeResolver.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.core.config;
 
@@ -51,8 +53,12 @@ class ClassNameFallbackPropertyTypeResolver extends StdTypeResolverBuilder {
 
         // important to get the normal TypeIdResolver!
         final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, false, true);
+        JavaType defaultType = null;
+        if( _defaultImpl != null ){
+            defaultType = config.getTypeFactory().constructType(_defaultImpl);
+        }
         return new ClassNameFallbackPropertyTypeDeserializer(baseType, idRes, _typeProperty, _typeIdVisible,
-                _defaultImpl);
+                defaultType);
     }
 }
 

--- a/self-service/forgerock-selfservice-example-ui/pom.xml
+++ b/self-service/forgerock-selfservice-example-ui/pom.xml
@@ -23,6 +23,7 @@
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -233,7 +234,6 @@
         <dependency>
             <groupId>de.matrixweb.osgi.wrapped</groupId>
             <artifactId>osgi-wrapped-rhino</artifactId>
-            <version>1.7R4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.mozilla</groupId>

--- a/self-service/pom.xml
+++ b/self-service/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -44,25 +45,8 @@
     </modules>
 
     <properties>
-        <javax.inject.version>1_2</javax.inject.version>
-        <commons-lang3.version>3.4</commons-lang3.version>
         <jackson-mapper-asl.version>1.9.2</jackson-mapper-asl.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.servicemix.bundles</groupId>
-                <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
-                <version>${javax.inject.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/util/forgerock-test-utils/pom.xml
+++ b/util/forgerock-test-utils/pom.xml
@@ -36,11 +36,13 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
