### PR TITLE
Issue openam#33 Upgrade unit testing frameworks

### DIFF
--- a/audit/forgerock-audit-core/pom.xml
+++ b/audit/forgerock-audit-core/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -68,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-core/src/test/java/org/forgerock/audit/AuditServiceImplTest.java
+++ b/audit/forgerock-audit-core/src/test/java/org/forgerock/audit/AuditServiceImplTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.audit;
@@ -28,7 +30,6 @@ import static org.forgerock.json.resource.Requests.newCreateRequest;
 import static org.forgerock.json.resource.Requests.newQueryRequest;
 import static org.forgerock.json.resource.Responses.newQueryResponse;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -70,6 +71,7 @@ import org.forgerock.json.resource.ServiceUnavailableException;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -108,7 +110,7 @@ public class AuditServiceImplTest {
 
         //then
         assertThat(auditService.isAuditing("access")).isTrue();
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -133,7 +135,7 @@ public class AuditServiceImplTest {
 
         //then
         assertThat(auditService.isAuditing(topic)).isFalse();
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -158,7 +160,7 @@ public class AuditServiceImplTest {
 
         //then
         assertThat(auditService.isAuditing("unknownTopic")).isFalse();
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(ResourceException.class);
     }
@@ -187,7 +189,7 @@ public class AuditServiceImplTest {
         //then
         verify(queryHandler, times(1)).publishEvent(any(Context.class), eq("access"), any(JsonValue.class));
         verify(otherHandler, times(1)).publishEvent(any(Context.class), eq("access"), any(JsonValue.class));
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(InternalServerErrorException.class);
     }
@@ -260,7 +262,7 @@ public class AuditServiceImplTest {
                         Requests.newDeleteRequest("_id"));
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(NotSupportedException.class);
     }
@@ -278,7 +280,7 @@ public class AuditServiceImplTest {
                         Requests.newPatchRequest("_id"));
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(NotSupportedException.class);
     }
@@ -296,7 +298,7 @@ public class AuditServiceImplTest {
                         Requests.newUpdateRequest("_id", new JsonValue(new HashMap<String, Object>())));
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(NotSupportedException.class);
     }
@@ -314,7 +316,7 @@ public class AuditServiceImplTest {
                         Requests.newActionRequest("access", "unknownAction"));
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(BadRequestException.class);
     }
@@ -364,7 +366,7 @@ public class AuditServiceImplTest {
                 auditService.handleCreate(new RootContext(), createRequest);
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(BadRequestException.class);
     }
@@ -388,7 +390,7 @@ public class AuditServiceImplTest {
                 auditService.handleCreate(new RootContext(), createRequest);
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(BadRequestException.class);
     }
@@ -559,7 +561,7 @@ public class AuditServiceImplTest {
                 auditService.handleCreate(new RootContext(), createRequest);
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(ServiceUnavailableException.class)
                 .hasMessage("AuditService not running");
@@ -576,7 +578,7 @@ public class AuditServiceImplTest {
                 auditService.handleRead(new RootContext(), readRequest);
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(ServiceUnavailableException.class)
                 .hasMessage("AuditService not running");
@@ -594,7 +596,7 @@ public class AuditServiceImplTest {
                 mock(QueryResourceHandler.class));
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .failedWithException()
                 .isInstanceOf(ServiceUnavailableException.class)
                 .hasMessage("AuditService not running");
@@ -654,7 +656,7 @@ public class AuditServiceImplTest {
 
         //then
         assertThat(auditService.isAuditing(topic)).isFalse();
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -689,7 +691,7 @@ public class AuditServiceImplTest {
 
         //then
         assertThat(auditService.isAuditing(topic)).isTrue();
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -721,7 +723,7 @@ public class AuditServiceImplTest {
                 auditService.handleRead(new RootContext(), readRequest);
 
         //then
-        assertThat(promise).failedWithException().isInstanceOf(BadRequestException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(BadRequestException.class);
         verifyZeroInteractions(otherAuditEventHandler);
     }
 
@@ -747,7 +749,7 @@ public class AuditServiceImplTest {
                 auditService.handleRead(new RootContext(), readRequest);
 
         //then
-        assertThat(promise).failedWithException().isInstanceOf(BadRequestException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(BadRequestException.class);
         verifyZeroInteractions(otherAuditEventHandler);
     }
 

--- a/audit/forgerock-audit-handler-csv/pom.xml
+++ b/audit/forgerock-audit-handler-csv/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -78,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-handler-csv/src/test/java/org/forgerock/audit/handlers/csv/CsvAuditEventHandlerTest.java
+++ b/audit/forgerock-audit-handler-csv/src/test/java/org/forgerock/audit/handlers/csv/CsvAuditEventHandlerTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.audit.handlers.csv;
@@ -22,7 +24,6 @@ import static org.forgerock.audit.AuditServiceBuilder.*;
 import static org.forgerock.audit.AuditServiceProxy.*;
 import static org.forgerock.audit.handlers.csv.CsvAuditEventHandler.*;
 import static org.forgerock.json.JsonValue.*;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -61,6 +62,7 @@ import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.ResultHandler;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -154,7 +156,7 @@ public class CsvAuditEventHandlerTest {
                 csvHandler.publishEvent(context, "access", createRequest.getContent());
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -182,7 +184,7 @@ public class CsvAuditEventHandlerTest {
                 csvHandler.readEvent(context, "access", readRequest.getResourcePathObject().tail(1).toString());
 
         //then
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .withObject()
                 .isInstanceOf(ResourceResponse.class);
@@ -230,7 +232,7 @@ public class CsvAuditEventHandlerTest {
                 csvHandler.queryEvents(context, "access", queryRequest, queryResourceHandler);
 
         //then
-        assertThat(promise).succeeded();
+        AssertJPromiseAssert.assertThat(promise).succeeded();
         verify(queryResourceHandler).handleResource(resourceCaptor.capture());
 
         final ResourceResponse resource = resourceCaptor.getValue();
@@ -268,7 +270,7 @@ public class CsvAuditEventHandlerTest {
         final Promise<ResourceResponse, ResourceException> promise =
                 auditEventHandler.publishEvent(context, "access", createRequest.getContent());
 
-        assertThat(promise)
+        AssertJPromiseAssert.assertThat(promise)
                 .succeeded()
                 .isInstanceOf(ResourceResponse.class);
 

--- a/audit/forgerock-audit-handler-elasticsearch/pom.xml
+++ b/audit/forgerock-audit-handler-elasticsearch/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -64,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-handler-elasticsearch/src/test/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandlerTest.java
+++ b/audit/forgerock-audit-handler-elasticsearch/src/test/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandlerTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.audit.handlers.elasticsearch;
 
@@ -22,8 +24,7 @@ import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.util.promise.Promises.newResultPromise;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +64,7 @@ import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.query.QueryFilter;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeTest;
@@ -169,7 +171,7 @@ public class ElasticsearchAuditEventHandlerTest {
                 handler.queryEvents(mock(Context.class), "access", queryRequest, queryResourceHandler);
 
         // then
-        assertThat(result).failedWithException().isInstanceOf(InternalServerErrorException.class);
+        AssertJPromiseAssert.assertThat(result).failedWithException().isInstanceOf(InternalServerErrorException.class);
     }
 
     @Test
@@ -212,7 +214,7 @@ public class ElasticsearchAuditEventHandlerTest {
                 handler.readEvent(context, "authentication", "fake-id-that-does-not-exist");
 
         // then
-        assertThat(responsePromise).failedWithException().isInstanceOf(NotFoundException.class);
+        AssertJPromiseAssert.assertThat(responsePromise).failedWithException().isInstanceOf(NotFoundException.class);
     }
 
     @Test

--- a/audit/forgerock-audit-handler-jdbc/pom.xml
+++ b/audit/forgerock-audit-handler-jdbc/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-handler-jms/pom.xml
+++ b/audit/forgerock-audit-handler-jms/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerTest.java
+++ b/audit/forgerock-audit-handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.audit.handlers.jms;
@@ -21,9 +23,8 @@ import static org.forgerock.audit.AuditServiceBuilder.newAuditService;
 import static org.forgerock.audit.json.AuditJsonConfig.parseAuditEventHandlerConfiguration;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
@@ -58,6 +59,7 @@ import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -161,7 +163,7 @@ public class JmsAuditEventHandlerTest {
                 Thread.sleep(100L); // small delay to simulate time to send message.
                 logger.info("message sent by session {}: {}",
                         sessionCount,
-                        invocation.getArgumentAt(0, TextMessage.class).getText());
+                        ((TextMessage)invocation.getArgument(0)).getText());
                 return null;
             }
         }).when(producer).send(textMessage);
@@ -298,7 +300,7 @@ public class JmsAuditEventHandlerTest {
                 jmsAuditEventHandler.publishEvent(null, "TEST_AUDIT", json(object(field("name", "TestEvent"))));
 
         // then
-        assertThat(promise).failedWithException().isInstanceOf(InternalServerErrorException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(InternalServerErrorException.class);
 
     }
 
@@ -322,7 +324,7 @@ public class JmsAuditEventHandlerTest {
         Promise<QueryResponse, ResourceException> response =
                 jmsAuditEventHandler.queryEvents(null, "TEST_AUDIT", Requests.newQueryRequest(""), null);
 
-        assertThat(response).failedWithException().isInstanceOf(NotSupportedException.class);
+        AssertJPromiseAssert.assertThat(response).failedWithException().isInstanceOf(NotSupportedException.class);
     }
 
     @Test
@@ -347,7 +349,7 @@ public class JmsAuditEventHandlerTest {
 
 
         // then
-        assertThat(response).failedWithException().isInstanceOf(NotSupportedException.class);
+        AssertJPromiseAssert.assertThat(response).failedWithException().isInstanceOf(NotSupportedException.class);
     }
 
     private JmsAuditEventHandlerConfiguration getDefaultConfiguration() throws Exception {

--- a/audit/forgerock-audit-handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JndiJmsContextManagerTest.java
+++ b/audit/forgerock-audit-handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JndiJmsContextManagerTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.audit.handlers.jms;
@@ -75,21 +77,21 @@ public class JndiJmsContextManagerTest {
      */
     @Test
     public void testContextLoading() throws Exception {
+        // Mock initialize
+        Context context = mock(Context.class);
+        InitialContextFactory initialContextFactory = mock(InitialContextFactory.class);
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        Topic topic = mock(Topic.class);
         // Given
-
         // Setup known mocked classloader and context builder to be used for validation.
         InitialContextFactoryBuilder builder = mock(InitialContextFactoryBuilder.class);
         setInitialContextFactoryBuilder(builder);
         ClassLoader contextClassLoader = mock(ClassLoader.class);
         Thread.currentThread().setContextClassLoader(contextClassLoader);
-        Context context = mock(Context.class);
-        InitialContextFactory initialContextFactory = mock(InitialContextFactory.class);
         when(initialContextFactory.getInitialContext(any(Hashtable.class))).thenReturn(context);
         when(builder.createInitialContextFactory(any(Hashtable.class))).thenReturn(initialContextFactory);
 
         // Setup JMS specific components for this test.
-        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-        Topic topic = mock(Topic.class);
         JndiConfiguration configuration = new JndiConfiguration();
         configuration.setJmsConnectionFactoryName("ConnectionFactory");
         configuration.setJmsTopicName("audit");

--- a/audit/forgerock-audit-handler-syslog/pom.xml
+++ b/audit/forgerock-audit-handler-syslog/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -79,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-json/pom.xml
+++ b/audit/forgerock-audit-json/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -66,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/audit/forgerock-audit-servlet/pom.xml
+++ b/audit/forgerock-audit-servlet/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015-2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -98,7 +99,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/src/test/java/org/forgerock/caf/authn/ModuleAuditingIT.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/src/test/java/org/forgerock/caf/authn/ModuleAuditingIT.java
@@ -12,12 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.caf.authn;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.forgerock.caf.authn.AuthModuleParameters.moduleArray;
 import static org.forgerock.caf.authn.AuthModuleParameters.moduleParams;
@@ -42,6 +43,7 @@ import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.DataProvider;
@@ -163,7 +165,7 @@ public class ModuleAuditingIT extends HandlerHolder {
 
         Promise<Response, NeverThrowsException> result = handler.handle(new AttributesContext(new RootContext()),
                 request);
-        assertThat(result).succeeded();
+        AssertJPromiseAssert.assertThat(result).succeeded();
         assertThat(result.get().getStatus().getCode()).isEqualTo(expectedResponseStatus);
 
         JsonValue auditRecords = getAuditRecords(handler);

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/src/test/java/org/forgerock/caf/authn/TestFramework.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/src/test/java/org/forgerock/caf/authn/TestFramework.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.caf.authn;
@@ -41,6 +43,7 @@ import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -84,7 +87,7 @@ class TestFramework {
         request.getHeaders().add("If-Match", "*");
         Promise<Response, NeverThrowsException> result = handler.handle(new AttributesContext(new RootContext()),
                 request);
-        assertThat(result).succeeded();
+        AssertJPromiseAssert.assertThat(result).succeeded();
         assertThat(result.get().getStatus()).isEqualTo(Status.OK);
     }
 
@@ -101,7 +104,7 @@ class TestFramework {
         request.getHeaders().add(ContentTypeHeader.valueOf("application/json; charset=UTF-8"));
         Promise<Response, NeverThrowsException> result = handler.handle(new AttributesContext(new RootContext()),
                 request);
-        assertThat(result).succeeded();
+        AssertJPromiseAssert.assertThat(result).succeeded();
         assertThat(result.get().getStatus()).isEqualTo(Status.OK);
         return json(result.get().getEntity().getJson());
     }
@@ -176,7 +179,7 @@ class TestFramework {
 
         Promise<Response, NeverThrowsException> result = handler.handle(new AttributesContext(new RootContext()),
                 request);
-        assertThat(result).succeeded();
+        AssertJPromiseAssert.assertThat(result).succeeded();
 
         Response response = result.get();
 

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/src/test/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModuleTest.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/src/test/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModuleTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.jaspi.modules.session.jwt;
@@ -63,7 +65,7 @@ import org.forgerock.json.jose.jwt.Jwt;
 import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.util.encode.Base64;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -602,7 +604,7 @@ public class ServletJwtSessionModuleTest {
 
         //Then
         assertEquals(authStatus, AuthStatus.SUCCESS);
-        verify(claimsSet).setIssuedAtTime(Matchers.<Date>anyObject());
+        verify(claimsSet).setIssuedAtTime(ArgumentMatchers.<Date>any());
         ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
         verify(response).addCookie(cookieCaptor.capture());
         Cookie newCookie = cookieCaptor.getValue();
@@ -708,19 +710,19 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>any())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>any())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>any())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claim(anyString(), any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claims(ArgumentMatchers.<String,Object>anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
         given(encryptedJwtBuilder.claims(claimsSet)).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.sign(any(HmacSigningHandler.class), eq(JwsAlgorithm.HS256)))
@@ -746,7 +748,7 @@ public class ServletJwtSessionModuleTest {
         verify(jwtClaimsSetBuilder).iat(iatCaptor.capture());
         verify(jwtClaimsSetBuilder).claim(eq(JwtSessionModule.TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY),
                 idleTimeoutCaptor.capture());
-        verify(jwtClaimsSetBuilder).claims(anyMap());
+        verify(jwtClaimsSetBuilder).claims(ArgumentMatchers.<String,Object>anyMap());
         verify(response).addCookie(cookieCaptor.capture());
 
 
@@ -797,19 +799,19 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>any())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>any())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>any())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claim(anyString(), any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claims(ArgumentMatchers.<String,Object>anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
         given(encryptedJwtBuilder.claims(claimsSet)).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.sign(any(HmacSigningHandler.class), eq(JwsAlgorithm.HS256)))
@@ -835,7 +837,7 @@ public class ServletJwtSessionModuleTest {
         verify(jwtClaimsSetBuilder).iat(iatCaptor.capture());
         verify(jwtClaimsSetBuilder).claim(eq(JwtSessionModule.TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY),
                 idleTimeoutCaptor.capture());
-        verify(jwtClaimsSetBuilder).claims(anyMap());
+        verify(jwtClaimsSetBuilder).claims(ArgumentMatchers.<String,Object>anyMap());
         verify(response).addCookie(cookieCaptor.capture());
 
 
@@ -925,19 +927,19 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>any())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>any())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>any())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claim(anyString(), any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claims(ArgumentMatchers.<String,Object>anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
         given(encryptedJwtBuilder.claims(claimsSet)).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.sign(any(HmacSigningHandler.class), eq(JwsAlgorithm.HS256)))
@@ -963,7 +965,7 @@ public class ServletJwtSessionModuleTest {
         verify(jwtClaimsSetBuilder).iat(iatCaptor.capture());
         verify(jwtClaimsSetBuilder).claim(eq(JwtSessionModule.TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY),
                 idleTimeoutCaptor.capture());
-        verify(jwtClaimsSetBuilder).claims(anyMap());
+        verify(jwtClaimsSetBuilder).claims(ArgumentMatchers.<String,Object>anyMap());
         verify(response).addCookie(cookieCaptor.capture());
 
 
@@ -1014,19 +1016,19 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>any())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>any())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>any())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claims(anyMapOf(String.class, Object.class))).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claim(anyString(), any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claims(ArgumentMatchers.<String,Object>anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
         given(encryptedJwtBuilder.claims(claimsSet)).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.sign(any(HmacSigningHandler.class), eq(JwsAlgorithm.HS256)))
@@ -1052,7 +1054,7 @@ public class ServletJwtSessionModuleTest {
         verify(jwtClaimsSetBuilder).iat(iatCaptor.capture());
         verify(jwtClaimsSetBuilder).claim(eq(JwtSessionModule.TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY),
                 idleTimeoutCaptor.capture());
-        verify(jwtClaimsSetBuilder).claims(anyMap());
+        verify(jwtClaimsSetBuilder).claims(ArgumentMatchers.<String,Object>anyMap());
         verify(response).addCookie(cookieCaptor.capture());
 
 
@@ -1102,19 +1104,19 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>any())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>any())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>any())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claim(anyString(), any())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.claims(ArgumentMatchers.<String,Object>anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
         given(encryptedJwtBuilder.claims(claimsSet)).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.sign(any(HmacSigningHandler.class), eq(JwsAlgorithm.HS256)))

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFilterTest.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFilterTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -21,7 +23,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.forgerock.caf.authentication.framework.AuthenticationFilter.AuthenticationFilterBuilder;
 import static org.forgerock.caf.authentication.framework.AuthenticationFilter.AuthenticationModuleBuilder.configureModule;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;
@@ -41,7 +43,7 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.testng.annotations.Test;
 
@@ -83,7 +85,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), responseHandlerCaptor.capture(),
                 serviceSubjectCaptor.capture(), eq(sessionAuthModule), authModulesCaptor.capture(),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
         assertThat(responseHandlerCaptor.getValue()).isNotNull();
@@ -110,7 +112,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), any(ResponseHandler.class),
                 any(Subject.class), eq(sessionAuthModule), anyListOf(AsyncServerAuthModule.class),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
     }
@@ -177,7 +179,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), responseHandlerCaptor.capture(),
                 eq(serviceSubject), eq(sessionAuthModule), authModulesCaptor.capture(),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
         assertThat(responseHandlerCaptor.getValue()).isNotNull();
@@ -218,9 +220,9 @@ public class AuthenticationFilterTest {
                 .build();
 
         //Then
-        verify(builder).createFilter(any(Logger.class), eq(auditApi), any(ResponseHandler.class), any(Subject.class),
-                any(AsyncServerAuthModule.class), anyListOf(AsyncServerAuthModule.class),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+        verify(builder).createFilter(nullable(Logger.class), eq(auditApi), nullable(ResponseHandler.class), nullable(Subject.class),
+                nullable(AsyncServerAuthModule.class), anyListOf(AsyncServerAuthModule.class),
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         verify(authModule).initialize(authModuleRequestPolicy, authModuleResponsePolicy,
                 authModuleHandler, authModuleSettings);

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/JaspiAdaptersTest.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/JaspiAdaptersTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -20,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.caf.authentication.framework.JaspiAdapters.MESSAGE_INFO_CONTEXT_KEY;
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;
@@ -44,6 +46,7 @@ import org.forgerock.caf.authentication.api.MessageInfoContext;
 import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.testng.annotations.Test;
 
 public class JaspiAdaptersTest {
@@ -66,7 +69,7 @@ public class JaspiAdaptersTest {
                 asyncAuthContext.validateRequest(messageContext, clientSubject, serviceSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SUCCESS);
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SUCCESS);
     }
 
     @Test
@@ -87,7 +90,7 @@ public class JaspiAdaptersTest {
                 asyncAuthContext.validateRequest(messageContext, clientSubject, serviceSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -107,7 +110,7 @@ public class JaspiAdaptersTest {
                 asyncAuthContext.secureResponse(messageContext, serviceSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SEND_SUCCESS);
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SEND_SUCCESS);
     }
 
     @Test
@@ -127,7 +130,7 @@ public class JaspiAdaptersTest {
                 asyncAuthContext.secureResponse(messageContext, serviceSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -143,7 +146,7 @@ public class JaspiAdaptersTest {
         Promise<Void, AuthenticationException> promise = asyncAuthContext.cleanSubject(messageContext, clientSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isNull();
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isNull();
         verify(authContext).cleanSubject(any(MessageInfo.class), eq(clientSubject));
     }
 
@@ -163,7 +166,7 @@ public class JaspiAdaptersTest {
         Promise<Void, AuthenticationException> promise = asyncAuthContext.cleanSubject(messageContext, clientSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -196,7 +199,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.initialize(requestPolicy, responsePolicy, handler, options);
 
         //Then
-        assertThat(promise).succeeded().withObject().isNull();
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isNull();
         verify(authModule).initialize(requestPolicy, responsePolicy, handler, options);
     }
 
@@ -218,7 +221,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.initialize(requestPolicy, responsePolicy, handler, options);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -255,7 +258,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.validateRequest(messageInfo, clientSubject, serviceSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SUCCESS);
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SUCCESS);
     }
 
     @Test
@@ -276,7 +279,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.validateRequest(messageInfo, clientSubject, serviceSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -296,7 +299,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.secureResponse(messageInfo, serviceSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SEND_SUCCESS);
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isEqualTo(AuthStatus.SEND_SUCCESS);
     }
 
     @Test
@@ -316,7 +319,7 @@ public class JaspiAdaptersTest {
                 asyncAuthModule.secureResponse(messageInfo, serviceSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test
@@ -332,7 +335,7 @@ public class JaspiAdaptersTest {
         Promise<Void, AuthenticationException> promise = asyncAuthModule.cleanSubject(messageInfo, clientSubject);
 
         //Then
-        assertThat(promise).succeeded().withObject().isNull();
+        AssertJPromiseAssert.assertThat(promise).succeeded().withObject().isNull();
         verify(authModule).cleanSubject(any(MessageInfo.class), eq(clientSubject));
     }
 
@@ -352,7 +355,7 @@ public class JaspiAdaptersTest {
         Promise<Void, AuthenticationException> promise = asyncAuthModule.cleanSubject(messageInfo, clientSubject);
 
         //Then
-        assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
+        AssertJPromiseAssert.assertThat(promise).failedWithException().isInstanceOf(AuthenticationException.class);
     }
 
     @Test

--- a/auth-filters/pom.xml
+++ b/auth-filters/pom.xml
@@ -115,7 +115,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-framework/binding-test-utils/pom.xml
+++ b/http-framework/binding-test-utils/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -52,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/http-framework/http-client-apache-async/src/test/java/org/forgerock/http/apache/async/AsyncClientTest.java
+++ b/http-framework/http-client-apache-async/src/test/java/org/forgerock/http/apache/async/AsyncClientTest.java
@@ -73,12 +73,12 @@ public class AsyncClientTest {
         // Clear mocked invocations between tests
         // So we can reuse the server instance (less traces) still having isolation
         if (server != null) {
-            server.getCalls().clear();
-            server.getStubs().clear();
+            server.clearCalls();
+            server.clearStubs();
         }
         if (httpsServer != null) {
-            httpsServer.getCalls().clear();
-            httpsServer.getStubs().clear();
+            httpsServer.clearCalls();
+            httpsServer.clearStubs();
         }
     }
 

--- a/http-framework/http-client-apache-sync/pom.xml
+++ b/http-framework/http-client-apache-sync/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2014-2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -41,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/http-framework/http-client-apache-sync/src/test/java/org/forgerock/http/apache/sync/SyncClientTest.java
+++ b/http-framework/http-client-apache-sync/src/test/java/org/forgerock/http/apache/sync/SyncClientTest.java
@@ -31,7 +31,7 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import com.xebialabs.restito.semantics.Predicate;
+import java.util.function.Predicate;
 import com.xebialabs.restito.semantics.Predicates;
 import org.forgerock.http.Client;
 import org.forgerock.http.handler.HttpClientHandler;
@@ -76,12 +76,12 @@ public class SyncClientTest {
         // Clear mocked invocations between tests
         // So we can reuse the server instance (less traces) still having isolation
         if (server != null) {
-            server.getCalls().clear();
-            server.getStubs().clear();
+            server.clearCalls();
+            server.clearStubs();
         }
         if (httpsServer != null) {
-            httpsServer.getCalls().clear();
-            httpsServer.getStubs().clear();
+            httpsServer.clearCalls();
+            httpsServer.clearStubs();
         }
     }
 

--- a/http-framework/http-core/pom.xml
+++ b/http-framework/http-core/pom.xml
@@ -15,6 +15,7 @@
   Copyright 2010–2011 ApexIdentity Inc.
   Portions Copyright 2011-2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -46,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/http-framework/http-core/src/test/java/org/forgerock/http/routing/RouterTest.java
+++ b/http-framework/http-core/src/test/java/org/forgerock/http/routing/RouterTest.java
@@ -12,14 +12,17 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.http.routing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -97,7 +100,7 @@ public class RouterTest {
         request.setUri("http://example.com:8080/json/users");
 
         given(routeMatcher.evaluate(any(Context.class), any(Request.class))).willReturn(routeMatch);
-        doThrow(IncomparableRouteMatchException.class).when(routeMatch).isBetterMatchThan(any(RouteMatch.class));
+        doThrow(IncomparableRouteMatchException.class).when(routeMatch).isBetterMatchThan(nullable(RouteMatch.class));
 
         //When
         Promise<Response, NeverThrowsException> promise = router.handle(context, request);

--- a/http-framework/http-grizzly/pom.xml
+++ b/http-framework/http-grizzly/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/http-framework/http-servlet/pom.xml
+++ b/http-framework/http-servlet/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/json-crypto/pom.xml
+++ b/json-crypto/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/json-ref/pom.xml
+++ b/json-ref/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -43,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/json-schema/pom.xml
+++ b/json-schema/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2012-2016 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -42,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/json-web-token/pom.xml
+++ b/json-web-token/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2011-2016 ForgeRock AS. All rights reserved.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -88,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/json-resource/src/test/java/org/forgerock/json/resource/RequestsTest.java
+++ b/rest/json-resource/src/test/java/org/forgerock/json/resource/RequestsTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.json.resource;
@@ -73,7 +75,7 @@ public final class RequestsTest {
         Request r = Requests.newReadRequest("test/users/forward%2fslash");
         assertThat(r.getResourcePath()).isEqualTo("test/users/forward%2fslash");
         assertThat(r.getResourcePathObject().leaf()).isEqualTo("forward/slash");
-        assertThat(r.getResourcePathObject().iterator()).hasSize(3);
+        assertThat(r.getResourcePathObject().iterator()).toIterable().hasSize(3);
     }
 
     @Test
@@ -81,7 +83,7 @@ public final class RequestsTest {
         Request r = Requests.newReadRequest("test/users", "forward/slash");
         assertThat(r.getResourcePath()).isEqualTo("test/users/forward%2Fslash");
         assertThat(r.getResourcePathObject().leaf()).isEqualTo("forward/slash");
-        assertThat(r.getResourcePathObject().iterator()).hasSize(3);
+        assertThat(r.getResourcePathObject().iterator()).toIterable().hasSize(3);
     }
 
     @Test
@@ -90,7 +92,7 @@ public final class RequestsTest {
                 Requests.newCreateRequest("test/users", "forward/slash", new JsonValue(null));
         assertThat(r.getResourcePath()).isEqualTo("test/users");
         assertThat(r.getResourcePathObject().leaf()).isEqualTo("users");
-        assertThat(r.getResourcePathObject().iterator()).hasSize(2);
+        assertThat(r.getResourcePathObject().iterator()).toIterable().hasSize(2);
         assertThat(r.getNewResourceId()).isEqualTo("forward/slash");
     }
 

--- a/rest/json-resource/src/test/java/org/forgerock/json/resource/RouterTest.java
+++ b/rest/json-resource/src/test/java/org/forgerock/json/resource/RouterTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.json.resource;
@@ -22,7 +24,6 @@ import static org.forgerock.http.routing.RoutingMode.EQUALS;
 import static org.forgerock.http.routing.RoutingMode.STARTS_WITH;
 import static org.forgerock.json.resource.RouteMatchers.requestUriMatcher;
 import static org.forgerock.json.resource.Router.uriTemplate;
-import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import org.forgerock.services.context.Context;
 import org.forgerock.http.routing.UriRouterContext;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.test.assertj.AssertJPromiseAssert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -297,7 +299,7 @@ public class RouterTest {
         Promise<ResourceResponse, ResourceException> promise = router.handleCreate(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -320,7 +322,7 @@ public class RouterTest {
         Promise<ResourceResponse, ResourceException> promise = router.handleRead(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -343,7 +345,7 @@ public class RouterTest {
         Promise<ResourceResponse, ResourceException> promise = router.handleUpdate(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -366,7 +368,7 @@ public class RouterTest {
         Promise<ResourceResponse, ResourceException> promise = router.handleDelete(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -389,7 +391,7 @@ public class RouterTest {
         Promise<ResourceResponse, ResourceException> promise = router.handlePatch(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -412,7 +414,7 @@ public class RouterTest {
         Promise<ActionResponse, ResourceException> promise = router.handleAction(context, request);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);
@@ -436,7 +438,7 @@ public class RouterTest {
         Promise<QueryResponse, ResourceException> promise = router.handleQuery(context, request, resultHandler);
 
         //Then
-        assertThat(promise).failedWithException();
+        AssertJPromiseAssert.assertThat(promise).failedWithException();
         try {
             promise.getOrThrowUninterruptibly();
             failBecauseExceptionWasNotThrown(ResourceException.class);

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/self-service/forgerock-selfservice-core/pom.xml
+++ b/self-service/forgerock-selfservice-core/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -57,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/self-service/forgerock-selfservice-json/pom.xml
+++ b/self-service/forgerock-selfservice-json/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -67,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/self-service/forgerock-selfservice-stages/pom.xml
+++ b/self-service/forgerock-selfservice-stages/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -77,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/captcha/CaptchaStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/captcha/CaptchaStageTest.java
@@ -12,13 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.captcha;
 
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 import org.forgerock.http.Client;
 import org.forgerock.http.Handler;
@@ -112,7 +114,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(newEmptyJsonValue());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseFailure());
+        given(handler.handle(nullable(Context.class), nullable(Request.class))).willReturn(newPromiseFailure());
         // When
         captchaStage.advance(context, config);
     }
@@ -126,7 +128,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(getInputCaptchaResponse());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseFailure());
+        given(handler.handle(nullable(Context.class), nullable(Request.class))).willReturn(newPromiseFailure());
         // When
         captchaStage.advance(context, config);
     }
@@ -137,7 +139,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(getInputCaptchaResponse());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseSuccess());
+        given(handler.handle(nullable(Context.class), nullable(Request.class))).willReturn(newPromiseSuccess());
         // When
         captchaStage.advance(context, config);
     }

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/email/VerifyEmailAccountStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/email/VerifyEmailAccountStageTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2015 ForgeRock AS.
  * Portions copyright 2019 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.email;
 
@@ -26,8 +27,8 @@ import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -199,7 +200,7 @@ public final class VerifyEmailAccountStageTest {
 
         // Then
         ArgumentCaptor<ActionRequest> actionRequestArgumentCaptor =  ArgumentCaptor.forClass(ActionRequest.class);
-        verify(connection).action(any(Context.class), actionRequestArgumentCaptor.capture());
+        verify(connection).action(nullable(Context.class), actionRequestArgumentCaptor.capture());
         ActionRequest actionRequest = actionRequestArgumentCaptor.getValue();
 
         assertThat(actionRequest.getAction()).isSameAs("send");

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/kba/SecurityAnswerVerificationStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/kba/SecurityAnswerVerificationStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.kba;
 
@@ -19,7 +21,7 @@ import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -128,7 +130,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newEmptyJsonValue());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -148,7 +150,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUserWithOnlyOneCustomQuestion());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -168,7 +170,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUserWithOnlyOneSystemQuestion());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -188,7 +190,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -212,7 +214,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         securityAnswerVerificationStage.advance(context, config);
@@ -231,7 +233,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), nullable(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         securityAnswerVerificationStage.advance(context, config);

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/registration/UserRegistrationStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/registration/UserRegistrationStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.registration;
 
@@ -20,7 +22,7 @@ import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;
@@ -107,7 +109,7 @@ public final class UserRegistrationStageTest {
 
         // Then
         ArgumentCaptor<CreateRequest> createRequestArgumentCaptor =  ArgumentCaptor.forClass(CreateRequest.class);
-        verify(connection).create(any(Context.class), createRequestArgumentCaptor.capture());
+        verify(connection).create(nullable(Context.class), createRequestArgumentCaptor.capture());
         CreateRequest createRequest = createRequestArgumentCaptor.getValue();
 
         assertThat(createRequest.getContent()).stringAt("givenName").isEqualTo("testUser");

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/reset/ResetStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/reset/ResetStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.reset;
 
@@ -20,7 +22,7 @@ import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;
@@ -103,7 +105,7 @@ public final class ResetStageTest {
 
         // Then
         ArgumentCaptor<PatchRequest> patchRequestArgumentCaptor =  ArgumentCaptor.forClass(PatchRequest.class);
-        verify(connection).patch(any(Context.class), patchRequestArgumentCaptor.capture());
+        verify(connection).patch(nullable(Context.class), patchRequestArgumentCaptor.capture());
         PatchRequest createRequest = patchRequestArgumentCaptor.getValue();
 
         PatchOperation patchOperation = createRequest.getPatchOperations().get(0);

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/EmailUsernameStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/EmailUsernameStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -21,7 +23,7 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -136,7 +138,7 @@ public final class EmailUsernameStageTest {
 
         // Then
         ArgumentCaptor<ActionRequest> actionRequestArgumentCaptor =  ArgumentCaptor.forClass(ActionRequest.class);
-        verify(connection).action(any(Context.class), actionRequestArgumentCaptor.capture());
+        verify(connection).action(nullable(Context.class), actionRequestArgumentCaptor.capture());
         ActionRequest actionRequest = actionRequestArgumentCaptor.getValue();
 
         assertThat(actionRequest.getAction()).isSameAs("send");

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/RetrieveUsernameStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/RetrieveUsernameStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -21,7 +23,7 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.forgerock.selfservice.stages.user.RetrieveUsernameStage.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/UserDetailsStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/UserDetailsStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -24,7 +26,7 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/UserQueryStageTest.java
+++ b/self-service/forgerock-selfservice-stages/src/test/java/org/forgerock/selfservice/stages/user/UserQueryStageTest.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -22,8 +24,8 @@ import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -179,7 +181,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), nullable(QueryRequest.class), nullable(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -197,7 +199,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), nullable(QueryRequest.class), nullable(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -215,7 +217,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), nullable(QueryRequest.class), nullable(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -241,7 +243,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), nullable(QueryRequest.class), nullable(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);

--- a/util/forgerock-test-utils/src/main/java/org/forgerock/json/test/assertj/AssertJJsonValueAssert.java
+++ b/util/forgerock-test-utils/src/main/java/org/forgerock/json/test/assertj/AssertJJsonValueAssert.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.json.test.assertj;
@@ -127,7 +129,7 @@ public final class AssertJJsonValueAssert {
          * Check that the {@link JsonValue} is a set.
          * @return The {@link AbstractIterableAssert} representation of this Assert instance.
          */
-        public AbstractIterableAssert<?, ? extends Iterable<?>, Object> isSet() {
+        public AbstractIterableAssert<?, ? extends Iterable<?>, Object, ?> isSet() {
             isNotNull();
             if (!actual.isSet()) {
                 failWithMessage("Expected %s to be a set", actual.getPointer());
@@ -534,7 +536,7 @@ public final class AssertJJsonValueAssert {
 
     /** Class for assertions on array {@link JsonValue}. */
     public static final class ArrayJsonValueAssert extends AbstractJsonValueAssert<ArrayJsonValueAssert> {
-        private AbstractListAssert<?, ? extends List<?>, Object> listAssert;
+        private AbstractListAssert<?, ? extends List<?>, Object, ?> listAssert;
 
         private ArrayJsonValueAssert(JsonValue value) {
             super(ArrayJsonValueAssert.class, value);

--- a/util/forgerock-test-utils/src/main/java/org/forgerock/util/test/assertj/AssertJPromiseAssert.java
+++ b/util/forgerock-test-utils/src/main/java/org/forgerock/util/test/assertj/AssertJPromiseAssert.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.util.test.assertj;
@@ -90,7 +92,7 @@ public final class AssertJPromiseAssert
          * @return A {@link AbstractIterableAssert} instance for making assertions on the value.
          */
         @SuppressWarnings("unchecked")
-        public <T> AbstractIterableAssert<?, ? extends Iterable<? extends T>, T> withIterable() {
+        public <T> AbstractIterableAssert<?, ? extends Iterable<? extends T>, T, ?> withIterable() {
             isInstanceOf(Iterable.class);
             return Assertions.assertThat((Iterable<T>) actual);
         }
@@ -102,7 +104,7 @@ public final class AssertJPromiseAssert
          * @return A {@link AbstractListAssert} instance for making assertions on the value.
          */
         @SuppressWarnings("unchecked")
-        public <T> AbstractListAssert<?, ? extends List<? extends T>, T> withList() {
+        public <T> AbstractListAssert<?, ? extends List<? extends T>, T, ?> withList() {
             isInstanceOf(List.class);
             return Assertions.assertThat((List<T>) actual);
         }

--- a/util/forgerock-util/pom.xml
+++ b/util/forgerock-util/pom.xml
@@ -13,6 +13,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -45,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Analysis

openam-jp/openam#33

OpenAM uses the following unit testing frameworks.

* TestNG 6.8.5
* AssertJ 2.1.0
* Mockito 1.9.5
* EasyMock 3.2
* Powermock 1.5
* JUnit 4.10

Some frameworks do not support Java 11.
For example, Mockito supports Java 11 from version 2.20.1.


## Solution
Upgrade unit testing frameworks. Then, tests will pass in Java 8 environment.
- TestNG 6.14.3
- AssertJ 3.13.2
- Mockito 2.28.2
- EasyMoch 4.0.2
- PowerMock 2.0.2
- Junit 4.12


## Install/Update
This fix relies on aggregation of dependencies on the BOM.
The unit testing frameworks are updated by BOM.
To apply the fix, get the modules in the following order and build them.

- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam


## Regression testing
Test results from testframework have not changed.
