### PR TITLE
Issue openam#32 Support Java 11 (OpenJDK 11)

### DIFF
--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -191,6 +191,10 @@
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+         </dependency>
 
         <!-- Module Dependencies -->
         <dependency>

--- a/http-framework/http-core/src/test/java/org/forgerock/http/header/HeaderUtilTest.java
+++ b/http-framework/http-core/src/test/java/org/forgerock/http/header/HeaderUtilTest.java
@@ -12,6 +12,8 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ *
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.http.header;
@@ -150,6 +152,33 @@ public class HeaderUtilTest {
         final Date result = HeaderUtil.parseDate("Sunday, 06-Nov-94 08:49:37 GMT");
         final String formattedDate = HeaderUtil.formatDate(result);
         assertThat(formattedDate).isEqualTo("Sun, 06 Nov 1994 08:49:37 GMT");
+
+        final Date monday = HeaderUtil.parseDate("Monday, 07-Nov-94 08:49:37 GMT");
+        final String mondayStr = HeaderUtil.formatDate(monday);
+        assertThat(mondayStr).isEqualTo("Mon, 07 Nov 1994 08:49:37 GMT");
+
+        final Date tuesday = HeaderUtil.parseDate("Tuesday, 08-Nov-94 08:49:37 GMT");
+        final String tuesdayStr = HeaderUtil.formatDate(tuesday);
+        assertThat(tuesdayStr).isEqualTo("Tue, 08 Nov 1994 08:49:37 GMT");
+
+        final Date wednesday = HeaderUtil.parseDate("Wednesday, 09-Nov-94 08:49:37 GMT");
+        final String wednesdayStr = HeaderUtil.formatDate(wednesday);
+        assertThat(wednesdayStr).isEqualTo("Wed, 09 Nov 1994 08:49:37 GMT");
+
+        final Date thursday = HeaderUtil.parseDate("Thursday, 10-Nov-94 08:49:37 GMT");
+        final String thursdayStr = HeaderUtil.formatDate(thursday);
+        assertThat(thursdayStr).isEqualTo("Thu, 10 Nov 1994 08:49:37 GMT");
+
+        final Date friday = HeaderUtil.parseDate("Friday, 11-Nov-94 08:49:37 GMT");
+        final String fridayStr = HeaderUtil.formatDate(friday);
+        assertThat(fridayStr).isEqualTo("Fri, 11 Nov 1994 08:49:37 GMT");
+
+        final Date saturday = HeaderUtil.parseDate("Saturday, 12-Nov-94 08:49:37 GMT");
+        final String saturdayStr = HeaderUtil.formatDate(saturday);
+        assertThat(saturdayStr).isEqualTo("Sat, 12 Nov 1994 08:49:37 GMT");
+
+        final Date missspel = HeaderUtil.parseDate("Sanday, 11-Nov-94 08:49:37 GMT");
+        assertThat(missspel).isNull();
     }
 
     @Test

--- a/json-web-token/pom.xml
+++ b/json-web-token/pom.xml
@@ -78,6 +78,14 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Analysis
openam-jp/openam#32

OpenAM now supports Java8.

While Java 8 is supported by various vendors, but public updates of Oracle Java will close soon.
Also, since release 9, the release model has changed.

OpenAM needs to support Java 11, the latest long-term support Java version.

## Solution
Support Java 11 (OpenJDK 11) as development environment and execution environment.

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam
