### PR TITLE
Issue openam#219 Upgrade Jackson library to 2.10.x

### DIFF
--- a/audit/forgerock-audit-json/src/test/java/org/forgerock/audit/json/AuditJsonConfigTest.java
+++ b/audit/forgerock-audit-json/src/test/java/org/forgerock/audit/json/AuditJsonConfigTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020 Open Source Solution Technology Corporation
  */
 package org.forgerock.audit.json;
 
@@ -63,7 +64,7 @@ public class AuditJsonConfigTest {
         return new Object[][] {
                 { "/audit-passthrough-handler-missing-name.json" },
                 { "/audit-passthrough-handler-missing-class.json" },
-                { "/audit-passthrough-handler-missing-events.json" }
+                { "/audit-passthrough-handler-no-events.json" }
         };
     }
 

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -192,9 +192,9 @@
             <artifactId>rest-assured</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-         </dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
 
         <!-- Module Dependencies -->
         <dependency>

--- a/json-web-token/pom.xml
+++ b/json-web-token/pom.xml
@@ -78,8 +78,8 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/rest/json-resource-http/pom.xml
+++ b/rest/json-resource-http/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeResolver.java
+++ b/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeResolver.java
@@ -14,6 +14,7 @@
  * Copyright 2015 ForgeRock AS.
  * 
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+ * Portions Copyrighted 2020 Open Source Solution Technology Corporation
  */
 package org.forgerock.selfservice.core.config;
 
@@ -52,7 +53,7 @@ class ClassNameFallbackPropertyTypeResolver extends StdTypeResolverBuilder {
             final DeserializationConfig config, final JavaType baseType, final Collection<NamedType> subtypes) {
 
         // important to get the normal TypeIdResolver!
-        final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, false, true);
+        final TypeIdResolver idRes = this.idResolver(config, baseType, null, subtypes, false, true);
         JavaType defaultType = null;
         if( _defaultImpl != null ){
             defaultType = config.getTypeFactory().constructType(_defaultImpl);


### PR DESCRIPTION
## Analysis
openam-jp/openam#217
openam-jp/openam#219

jackson is a parsing library for Cbor.
WebAuthn Authentication module use it and older version has problem in parsing authenticatorData.

and older version has some security Issues from CVE.
*CVE-2019-17267
*CVE-2020-9547
*CVE-2020-10673
*CVE-2020-9548
*CVE-2019-14892

## Solution
Upgrade jackson to 2.10.4.

## Testing
Unit tests works fine.