### PR TITLE
Issue #21 ECDSASigningHandlerTest fails sometimes

### DIFF
--- a/json-web-token/src/main/java/org/forgerock/json/jose/utils/DerUtils.java
+++ b/json-web-token/src/main/java/org/forgerock/json/jose/utils/DerUtils.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2023 OSSTech Corporation
  */
 
 package org.forgerock.json.jose.utils;
@@ -78,8 +78,8 @@ public final class DerUtils {
         Reject.ifNull(signature);
 
         final int midPoint = signatureSize >> 1;
-        final BigInteger r = new BigInteger(Arrays.copyOfRange(signature, 0, midPoint));
-        final BigInteger s = new BigInteger(Arrays.copyOfRange(signature, midPoint, signature.length));
+        final BigInteger r = new BigInteger(1, Arrays.copyOfRange(signature, 0, midPoint));
+        final BigInteger s = new BigInteger(1, Arrays.copyOfRange(signature, midPoint, signature.length));
 
         // Each integer component needs at most 2 bytes for the length field and 1 byte for the tag, for a total of 6
         // bytes for both integers.

--- a/json-web-token/src/test/java/org/forgerock/json/common/util/DerUtilsTest.java
+++ b/json-web-token/src/test/java/org/forgerock/json/common/util/DerUtilsTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2013-2015 ForgeRock AS.
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+ * Portions Copyrighted 2023 OSSTech Corporation
  */
 
 package org.forgerock.json.common.util;
@@ -65,7 +66,16 @@ public class DerUtilsTest {
     @DataProvider(name = "derEncodeContext")
     private Object[][] getDerEncodeContextData() {
 		return new Object[][] {
-			{"Certificate: Data: Version: 3 (0x2) Serial Number:", "3036021943657274696669636174653A20446174613A2056657273696F02196E3A20332028307832292053657269616C204E756D6265723A"},
+			{"0000", "3006020100020100"},
+			{"00FF", "3007020100020200FF"},
+			{"FF00", "3007020200FF020100"},
+			{"FFFF", "3008020200FF020200FF"},
+			{"00000000", "3006020100020100"},
+			{"0000FFFF", "3008020100020300FFFF"},
+			{"FFFF0000", "3008020300FFFF020100"},
+			{"FFFFFFFF", "300A020300FFFF020300FFFF"},
+			// "43657274..." is the hexadecimal representation of "Certificate: Data: Version: 3 (0x2) Serial Number:".
+			{"43657274696669636174653A20446174613A2056657273696F6E3A20332028307832292053657269616C204E756D6265723A", "3036021943657274696669636174653A20446174613A2056657273696F02196E3A20332028307832292053657269616C204E756D6265723A"}
 		};
 	}
 
@@ -75,8 +85,8 @@ public class DerUtilsTest {
 	}
 
 	@Test(dataProvider = "derEncodeContext")
-	public void encodeTest(String signature, String expectedHex) {
-		byte[] result = DerUtils.encode(signature.getBytes(), signature.length());
+	public void encodeTest(String targetHex, String expectedHex) {
+		byte[] result = DerUtils.encode(DatatypeConverter.parseHexBinary(targetHex), targetHex.length() / 2);
 		assertThat(DatatypeConverter.printHexBinary(result)).isEqualTo(expectedHex);
 	}
 
@@ -87,9 +97,9 @@ public class DerUtilsTest {
 	}
 
 	@Test(dataProvider = "derEncodeContext")
-	public void decodeTest(String expectedSignature, String encodedHex)
+	public void decodeTest(String expectedHex, String targetHex)
 			throws SignatureException, UnsupportedEncodingException {
-		byte[] result = DerUtils.decode(DatatypeConverter.parseHexBinary(encodedHex), expectedSignature.length());
-		assertThat(new String(result, "UTF-8")).isEqualTo(expectedSignature);
+		byte[] result = DerUtils.decode(DatatypeConverter.parseHexBinary(targetHex), expectedHex.length() / 2);
+		assertThat(DatatypeConverter.printHexBinary(result)).isEqualTo(expectedHex);
 	}
 }


### PR DESCRIPTION
# Solution

Fix to explicitly specify that the number is positive when passing it to the BigInteger constructor in DerUtils.encode(). This fixes the problem of the number being encoded to a different value than it was before decoding, and as a result, ECDSASigningHandlerTest#shouldVerifyCorrectly will no longer fail.

# Testing

I executed the following command once and confirmed that it did not fail:
```bash
$ mvn test -f json-web-token
```

I executed the following command 100,000 times and confirmed that it never failed:
```bash
$ mvn test -f json-web-token -Dtest=ECDSASigningHandlerTest
```