### PR TITLE
Issue #23 Build fails because cargo plugin cannot start tomcat

### DIFF
--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -13,7 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2016 ForgeRock AS.
-* Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019-2024 OSSTech Corporation
 * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -104,7 +104,7 @@
                     <container>
                         <containerId>tomcat7x</containerId>
                         <zipUrlInstaller>
-                            <url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.47/bin/apache-tomcat-7.0.47.zip</url>
+                            <url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.47/bin/apache-tomcat-7.0.47.zip</url>
                             <downloadDir>${project.build.directory}/downloads</downloadDir>
                             <extractDir>${project.build.directory}/extracts</extractDir>
                         </zipUrlInstaller>


### PR DESCRIPTION
## Analysis

When I checked the tomcat archive generated when the build failed, I found that it contained the content of the HTTP 301 response as shown below.

```
$ cat apache-tomcat-7.0.47.zip
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.47/bin/apache-tomcat-7.0.47.zip">here</a>.</p>
</body></html>
```

The Cargo plugin probably doesn't support HTTP 301, so we need to change the download URL.


## Solution

Fixed Tomcat download URL scheme from HTTP to HTTPS.

## Testing

```
$ mvn clean install -f auth-filters
```