### PR TITLE
Issue openam#302 Build fails with Maven 3.9.10

### DIFF
--- a/http-framework/http-benchmarks/pom.xml
+++ b/http-framework/http-benchmarks/pom.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2016 ForgeRock AS.
-  Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019-2025 OSSTech Corporation
   Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -62,7 +62,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
## Analysis

openam-jp/openam#302

## Solution

Bump maven-shade-plugin version to 3.6.0.

For this purpose, refer to maven-shade-plugin version in forgerock-parent.