### PR TITLE
Issue openam#355 The response from the REST API includes details of JSON parse errors

### DIFF
--- a/rest/json-resource-http/src/main/java/org/forgerock/json/resource/http/HttpUtils.java
+++ b/rest/json-resource-http/src/main/java/org/forgerock/json/resource/http/HttpUtils.java
@@ -865,8 +865,7 @@ public final class HttpUtils {
         } catch (final JsonParseException e) {
             throw new BadRequestException(
                     "The request could not be processed because the provided "
-                            + "content is not valid JSON", e)
-                .setDetail(new JsonValue(e.getMessage()));
+                            + "content is not valid JSON", e);
         } catch (final JsonMappingException e) {
             if (allowEmpty) {
                 return null;


### PR DESCRIPTION
## Solution

Do not include details of JSON parse errors in the REST API response.

## Testing

The REST API response of OpenAM does not include details of JSON parse errors.